### PR TITLE
FIX: Duplicated keys

### DIFF
--- a/src/connectReactGridLayoutBuilder.js
+++ b/src/connectReactGridLayoutBuilder.js
@@ -10,15 +10,6 @@ var connectReactGridLayoutBuilder = ReactGridLayout => class extends Component {
     updateConfigFunc: PropTypes.func.isRequired
   })
 
-  // Callback so you can save the layout.
-  onLayoutChange = (currentLayout, allLayouts) => {
-    var reactGridLayout = _.cloneDeep(getReactGridLayoutFromProps(this.props));
-    reactGridLayout.layouts = allLayouts;
-    if (this.props.onLayoutChange) {
-      this.props.onLayoutChange(currentLayout, allLayouts)
-    }
-    this.props.updateConfigFunc(reactGridLayout);
-  }
   // Calls when drag starts.
   onDragStart = (layout, oldItem, newItem, placeholder, e, element) => {
     if (this.props.onDragStart) {
@@ -127,7 +118,6 @@ var connectReactGridLayoutBuilder = ReactGridLayout => class extends Component {
         onDragStart={this.onDragStart}
         onDrag={this.onDrag}
         onDragStop={this.onDragStop}
-        onResizeStart={this.onResizeStart}
         onResizeStart={this.onResizeStart}
         onResize={this.onResize}
         onResizeStop={this.onResizeStop}


### PR DESCRIPTION
`onLayoutChange` was defined twice I'm not sure but I think the first one is overwritten by the second one.
`onResizeStart` was defined twice in `ReactGridLayout` property list.

I was going to fix the

```javascript
onLayoutChange = (...) => { ... }
```
with

```javascript
onLayoutChange(...) { ... }
```

But I'm not sure if there's some intention after that.